### PR TITLE
Call rnd(table) to get a random table element

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,6 +450,7 @@ all(t) -- used in 'for v in all(t)' loops
 count(t) -- returns number of elements in the table
 del(t, v) -- delete first instance of v in t
 foreach(t, f) -- call f() for each v in t
+rnd(t) -- returns a random element from t
 pairs(t) -- used in 'for k,v in pairs(t)' loops</code></pre>
 
           <h6>metatables :: <u><a href="http://www.lexaloffle.com/bbs/?tid=3342" target="_blank" style="color: white;">view metatables thread</a></u></h6>


### PR DESCRIPTION
As of 2.0.0, you can call `rnd` with a table as the argument to get a random element from the table.

This PR adds that to the `tables` tab.

From the [PICO-8 manual](https://www.lexaloffle.com/pico-8.php?page=manual):
```
	rnd x
		Returns a random number n, where 0 <= n < x
		If you want an integer, use flr(rnd(x))
		If x is an array-style table, return a random element between table[1] and table[#table].
```